### PR TITLE
Fixed finding dependencies, added cache folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 assets/config.json
 assets/user-path-backup.txt
 .vscode
+cache

--- a/aris.ahk
+++ b/aris.ahk
@@ -1240,7 +1240,8 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
             Print "Found dependencies in extracted package manifest"
             for DependencyName, DependencyVersion in PackageJson["dependencies"] {
                 Print "Starting install of dependency " DependencyName "@" DependencyVersion
-                DownloadPackageWithDependencies(DependencyName "@" DependencyVersion, TempDir, Includes)
+                DependencyEntry := DependencyEntryToPackageInfo(DependencyName, DependencyVersion)
+                DownloadPackageWithDependencies(DependencyEntry, TempDir, Includes)
             }
         }
     }


### PR DESCRIPTION
This is the `DependencyEntry` fix based on our conversation. That 2-line change you suggested did the trick:
![image](https://github.com/user-attachments/assets/dbe94972-c48f-4744-9fc4-b4f7bb42cc52)

I also incidentally added the `cache` folder to `.gitignore` so random unintended files don't get scooped up. :)

Thanks again for your help!