### PR TITLE
Detailed and colorful output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,24 @@ Most of the following examples will use the command line interface, but most pac
 
 ## Introductory example
 For example, to install my (Descolada) OCR package:
-1. Run Aris.ahk, select your project folder, choose the Index tab, and double-click "Descolada/OCR"
-2. Alternatively open command prompt or Powershell, navigate to your project folder, run `aris i Descolada/OCR`. Note: the Aris GUI needs to be started at least once before this, otherwise Aris isn't added to PATH.
+1. Run `Aris.ahk`, select your project folder, choose the Index tab, and double-click "Descolada/OCR"
+2. Alternatively open command prompt or Powershell, navigate to your project folder, run `aris i Descolada/OCR`. 
+> [!note]
+> The Aris GUI needs to be started at least once before this, otherwise Aris isn't added to the PATH variable.
 
-Then either use the generated #include directive (in this case `#include <Aris/Descolada/OCR>`) or include all installed packages with `#include <packages>`
+Then either use the generated `#include` directive (in this case `#include <Aris/Descolada/OCR>`) or include all installed packages with `#include <packages>`
 
 ## Aris command arguments
+
+To see supported commands and switches from terminal, specify `-h` or `--help` switch accodring to examples:
+| example | description |
+|--------|--------|
+| aris -h | detailed help message |
+| aris _install_ -h | specific command help |
+|  aris _--force_ -h | specific switch help |
+|  aris -h _commands_ | specific help topic |
+|  aris -h _commands_,_switches_,... | specific help topics |
+
 ### Install
 `aris install package` installs the specified package from the specified source, see examples further down.
 Command aliases: `i`
@@ -124,11 +136,15 @@ aris i https://github.com/Descolada/UIA-v2/archive/refs/heads/main.zip
 # Developer info
 
 ## Adding packages to index
-The minimum information for an index.json entry is "description", "main", and "repository". If the package consists of more than a single file and not all files in the package are needed, then the "files" array should be filled with the appropriate file names or wildcard patterns. In that case "main" also needs to be specified with the relative path to the file, but doesn't need to be duplicated in the "files" array. 
+
+To add your own package or someone else's package to Aris, you need to add an entry to the [index.json](/assets/index.json) and submit a [Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+
+The minimum information for an [index.json](/assets/index.json) entry is "description", "main", and "repository". If the package consists of more than a single file and not all files in the package are needed, then the "files" array should be filled with the appropriate file names or wildcard patterns. In that case "main" also needs to be specified with the relative path to the file, but doesn't need to be duplicated in the "files" array. 
+
 Including a GitHub repo branch name is optional and will default to the default branch.
 
 Example minimal entry, which downloads all files in the repository and sets main.ahk as the entry-point. "files" is implicitly ["*.*"] in this case.
-```
+```json
 	"Author/Name": {
 		"description": "A short package description",
 		"main": "main.ahk",
@@ -136,7 +152,7 @@ Example minimal entry, which downloads all files in the repository and sets main
 	}
 ```
 Example multiple files minimal entry, which downloads the assets folder, include.ahk and main.ahk:
-```
+```json
 	"Author/Name": {
 		"description": "A short package description",
 		"main": "subfolder/main.ahk",
@@ -144,6 +160,18 @@ Example multiple files minimal entry, which downloads the assets folder, include
 		"repository": "Author/repo/branch"
 	}
 ```
+The package must be hosted in a [supported repository](#install) (like GitHub). If it is posted on a forum or available via another link, **it must first be submitted to [ScriptHub](https://github.com/ahkscript/ScriptHub)**! Then you can specify it in your package with additional "homepage" string that points to the source URL. 
+Example for `FileReadLine.ahk` from [AHK forum](https://www.autohotkey.com/boards/viewtopic.php?f=83&t=117999):
+```json
+    "Descolada/FileReadLine": {
+        "description": "Read a single line from a file",
+        "files": "v2/Descolada/FileReadLine.ahk",
+        "homepage": "https://www.autohotkey.com/boards/viewtopic.php?f=83&t=117999",
+        "repository": "ahkscript/ScriptHub/main"
+    }
+```
+> [!tip]
+> If you're too lazy to fill index or you found multiple packages, please [send private message to Descolada](https://www.autohotkey.com/boards/memberlist.php?mode=viewprofile&u=141239) or [contact Rafaello](https://github.com/JoyHak): [AutoHotkey](https://www.autohotkey.com/boards/memberlist.php?mode=viewprofile&u=177013), [Discord](https://discord.com/users/450899199010144267), [E-Mail](mailto:rafaello@disroot.org).
 
 # Roadmap
 Not in order of priority:

--- a/aris.ahk
+++ b/aris.ahk
@@ -1,36 +1,166 @@
-/*
-    ARIS: AutoHotkey Repository Install System
+#Requires AutoHotkey v2
+#SingleInstance Off
+#include <print>
 
-    Requirements that Aris must fulfill and situations it must handle:
-    1) Installing a library should either install it in the local Lib folder, or the Lib folder in My Documents\AutoHotkey for global installs.
-    2) Installation creates a packages.ahk file, which also acts as a lock file describing the exact dependencies needed.
-    3) Installation creates a package.json file to describe the range of dependencies allowed. This should
-        be done automatically without needing user input, as most users simply want to use a library, not enter info
-        about their own project.
-    4) If an installed library has package.json, then its dependencies should also be installed in the main Lib folder
-    5) A package is considered "installed" if it has an entry in package.json dependencies, packages.ahk #include,
-        and it has an install folder in Lib folder
-    6) "aris install" should query for package.json, packages.ahk, and search all project main folder and lib folder .ahk files for matching
-        ARIS version style "Aris/Author/Name".
-    7) Dependencies should also be findable if a package.json and packages.ahk don't exist. In that case
-        all .ahk files should be queried for matching ARIS version styles AND that entry must contain
-        all pertinent information for installing the package.
-        This is especially important with archive installs or Gists, as the ARIS version will contain
-        only a hash, which means the source will need to be added as a comment after it. The source is 
-        optional for GitHub installs.
-    8) Supported install locations/commands:
-        aris i Name          => queries index.json for a matching package, and if only 1 match is found then it's installed
-        aris i Author/Name   => queries index.json, otherwise falls back to GitHub main branch
-        aris i Name@version  => Requires a specific version range. If a specific version is specified then other installed versions are automatically removed.
-        aris i Name@ShortHash    => Requires a specific GitHub commit
-        aris i Author/Name/branch    => installs a GitHub branch
-        aris i github:URL    => installs from a GitHub link. URL can also be in the short form Author/Name
-        aris i gist:hash         => installs the first found file in a Gist
-        aris i gist:hash/file    => installs a specific file from a Gist
-        aris i forums:t=thread-id  => Installs from a AHK forums thread, the first encountered code-box
-        aris i forums:t=thread-id&codebox=number  => Installs from a AHK forums thread, optionally a codebox number can be specified
-        aris i URL           => GitHub URL, or AHK forums URL, or an archive (.zip, .tar.bz) link
-*/
+({}.DefineProp)(String.prototype, 'Color', {call: Colorize})
+({}.DefineProp)(String.prototype, 'Strip', {call: DeColorize})
+
+
+PrintHelp(topics := '') {
+    static title := 'ARIS: AutoHotkey Repository Install System'
+    
+    static commands := OrderedMap(
+    "INSTALL",
+    (`
+    '#install (i)
+        Installs the specified package from the specified source.
+        If the package is already installed then its forcibly uninstalled 
+        and then reinstalled with the specific version.
+         
+        **Quick install from:**
+        aris i Name                 index.json if there is exactly 1 matching package 
+        aris i Author/Name          index.json 1st matching package. Falls back to GitHub main branch.
+            
+        **Install from:**
+        aris i Author/Name/branch   GitHub branch
+        aris i github:URL           GitHub link. URL can also be in the short form: Author/Name
+        aris i gist:hash            1st found file in a Gist
+        aris i gist:hash/file       specific file from a Gist
+        aris i forums:t=thread-id   AHK forum thread, 1st encountered code-box
+        
+        aris i forums:t=thread-id&codebox=number  AHK forum thread, optionally a codebox number can be specified
+        aris i URL                  GitHub URL, or AHK forum URL, or an archive (`.zip, .tar.gz`) link
+        
+        **Requirements:**
+        aris i Name@ShortHash       Requires a specific GitHub commit
+        aris i Name@latest
+        aris i Name@version         Requires a specific version range. 
+                                    If a specific version is specified then other installed versions are automatically removed.
+                                    
+        aris i _package_@latest       Append @latest to any source above to install the latest version: 
+                                    `aris Descolada/Misc@latest`
+                                    `aris github:_URL_@latest` '
+    ), 
+    "REMOVE", 
+    (`       
+    '#remove (unistall, rm, r)
+        Removes the package. Specify either the full package name, or only the name without the author:
+        `aris rm Descolada/Misc`
+        `aris rm Misc` '
+    ), 
+    "UPDATE", 
+    (`    
+    '#update
+        Updates to the latest allowed version specified in the package.json file.
+        Update to the latest version using hash:
+        `aris install package@latest` '
+    ), 
+    "LIST", 
+    (`    
+    '#list
+        Lists all installed packages.'
+    ),
+    "CLEAN", 
+    (`
+    '#clean 
+        Removes unused entries from package.json dependencies and packages.ahk'
+    )
+    )
+    
+    static switches := OrderedMap(
+    'FILES',            '--files         specific files mask: `RapidOcr/*.*`, `MCode.ahk`, ...', 
+    'MAIN',             '--main,    -m   specific main file: `RapidOcr/*.*`, `MCode.ahk`, ...', 
+    'VERSION',          '--version, -v   get package version', 
+    'GLOBAL_INSTALL',   '--global,  -g   package in "Documents/AutoHotkey/Lib"', 
+    'LOCAL_INSTALL',    '--local,   -l   package in local "Lib"', 
+    'FORCE',            '--force,   -f   install/update package even if its installed/up to date', 
+    'HELP',
+    (`
+    '#--help (-h)
+        aris -h             detailed help message
+        aris _install_ -h     specific command help
+        aris _--force_ -h     specific switch help
+        aris -h _commands_    specific help topic
+        aris -h _commands_,_switches_,...     specific help topics'
+    )
+    )
+    
+    static requirements := 
+    (`
+    '#Requirements that Aris must fulfill and situations it must handle:
+    1. Installing a library should either install it in the local Lib folder, 
+       or the Lib folder in "My Documents\AutoHotkey" for global installs.
+    2. Installation creates a packages.ahk file, which also acts as a lock file 
+       describing the exact dependencies needed.
+    3. Installation creates a package.json file to describe the range of dependencies allowed. 
+       This should be done automatically without needing user input, as most users simply want to use a library, 
+       not enter info about their own project.
+    4. If an installed library has package.json, then its dependencies should also 
+       be installed in the main Lib folder
+    5. A package is considered installed if it has an entry in
+       package.json dependencies, packages.ahk `#include`,
+       and it has an install folder in Lib folder
+    6. `aris install` should query for package.json, packages.ahk, 
+       and search all project main folder and Lib folder .ahk files 
+       for matching ARIS version style: "Aris/Author/Name".
+    7. Dependencies should also be findable if a package.json and packages.ahk dont exist. 
+       In that case all .ahk files should be queried for matching ARIS version styles 
+       AND that entry must contain **all pertinent information** for installing the package.
+       This is especially important with archive installs or Gists, as the ARIS version will contain
+       only a hash, which means the source will need to be added as a comment after it. 
+       The source is optional for GitHub installs.'
+    )
+    
+    Str(m, title := '') {
+        ; Consistent output for any case
+        if (m is String)
+            return m "`n`n"
+            
+        title .= "`n"
+        for _, value in m {
+            title .= value "`n`n"
+        }
+        
+        return title
+    }
+    
+    msg := ''
+    for topic in topics {
+        if g_CommandAliases.Has(topic)
+            msg .= commands[topic] '`n'
+        else if g_Switches.Has(topic)
+            msg .= switches[topic] '`n'
+        else if g_SwitchAliases.Has(topic)
+            msg .= switches[g_SwitchAliases[topic]] '`n'
+        else if IsSet(%topic%)
+            msg .= Str(%topic%, '#' topic)
+    } 
+    
+    if !msg {
+        msg := 
+          Str(title)
+          . Str(commands, '#Commands')
+          . Str(switches, '#Switches')
+          . Str(requirements)
+    }
+    
+    
+    msg := 
+      msg.Color('("[^"]+")',               "blue")            ; quote
+         .Color('``([^``]+)``',            "purple")          ; code
+         .Color('_([^_]+)_',               "green")           ; italic
+         .Color('\*\*([^*]+)\*\*',         "cyan",   true)    ; bold
+         .Color('m)^[ \t]*#(.+)$',         "yellow", true)    ; header
+         .Color('\b(aris i)\b',            "gray")            ; aris install
+         .Color('( \.ahk )',               "cyan")            ; .ahk
+         .Color('( \w+\.(json|ahk) )',     "cyan")            ; files
+         .Color('(\-+\w+)\b',              "cyan")            ; switches
+         .Color('(@\w+)',                  "blue")            ; @ prefix
+         .Color('([:=])(?=\w)',            "blue")            ; : source
+         .Color('(thread-id)',             "green")            
+    
+    Print(Trim(msg, "`n"))
+}
 
 ; Raw files:
 ; https://github.com/user/repository/raw/branch/filename
@@ -55,13 +185,10 @@
 ; Gist links:
 ; https://gist.github.com/raw/[ID]/[REVISION]/[FILE]
 
-#Requires AutoHotkey v2
-
-#SingleInstance Off
 
 TraySetIcon A_ScriptDir "\assets\main.ico"
 Print.Buffer := ""
-OnError(PrintError)
+OnError(PrintException)
 
 #include <Aris/FanaticGuru/GuiReSizer>
 #include <Aris/G33kDude/cJson>
@@ -71,12 +198,13 @@ OnError(PrintError)
 #include <hash>
 #include <web>
 #include <env>
+#include <OrderedMap>
 
 global g_GitHubRawBase := "https://raw.githubusercontent.com/Descolada/ARIS/main/"
 global g_Index, g_Config := Map(), g_PackageJson, g_LocalLibDir := A_WorkingDir "\Lib\Aris", g_GlobalLibDir := A_MyDocuments "\AutoHotkey\Lib\Aris", g_InstalledPackages, g_GlobalInstalledPackages
-global g_Switches := Mapi("local_install", false, "global_install", false, "force", false), g_CacheDir := A_ScriptDir "\cache"
+global g_Switches := Mapi("local_install", false, "global_install", false, "force", false, "help", false), g_CacheDir := A_ScriptDir "\cache"
 global g_CommandAliases := Mapi("install", "install", "i", "install", "remove", "remove", "r", "remove", "rm", "remove", "uninstall", "remove", "update", "update", "update-index", "update-index", "list", "list", "clean", "clean")
-global g_SwitchAliases := Mapi("--global", "global_install", "--global-install", "global_install", "-g", "global_install", "--local", "local_install", "--local-install", "local_install", "-l", "local_install", "-f", "force", "--force", "force", "--main", "main", "-m", "main", "--files", "files", "--alias", "alias", "as", "alias")
+global g_SwitchAliases := Mapi("--global", "global_install", "--global-install", "global_install", "-g", "global_install", "--local", "local_install", "--local-install", "local_install", "-l", "local_install", "-f", "force", "--force", "force", "--main", "main", "-m", "main", "--files", "files", "--alias", "alias", "as", "alias", "-h", "help", "--help", "help")
 global g_MainGui := Gui("+MinSize640x400 +Resize", "Aris")
 global g_AddedIncludesString := ""
 global g_IsComSpecAvailable := false
@@ -92,8 +220,6 @@ if !A_Args.Length && !DllCall("GetStdHandle", "int", -11, "ptr") { ; Hack to det
 }
 
 try g_IsComSpecAvailable := !RunWait(A_ComSpec " /c echo 1",, "Hide")
-
-Console := DllCall("AttachConsole", "UInt", 0x0ffffffff, "ptr")
 
 for i, Arg in A_Args {
     switch Arg, 0 {
@@ -113,16 +239,18 @@ if !g_Config.Has("auto_update_index_daily") || (g_Config["auto_update_index_dail
 }
 
 if g_Config["add_to_path"] && !IsArisInPATH() {
-    try AddArisToPATH()
+    try 
+        AddArisToPATH()
     catch
-        Print "Failed to add Aris to PATH (missing rights to write to registry?)"
+        PrintError("Failed to add Aris to PATH (missing rights to write to registry?)")
 } else if g_Config.Has("add_to_path") && !g_Config["add_to_path"] && IsArisInPATH(0)
     try RemoveArisFromPATH()
 
 if g_Config["add_to_shell"] && !IsArisShellMenuItemPresent() {
-    try AddArisShellMenuItem()
+    try 
+        AddArisShellMenuItem()
     catch
-        Print "Failed to add Aris shell menu item (missing rights to write to registry?)"
+        PrintError("Failed to add Aris shell menu item (missing rights to write to registry?)")
 } else if g_Config.Has("add_to_shell") && !g_Config["add_to_shell"] && IsArisShellMenuItemPresent(0)
     try RemoveArisShellMenuItem()
 
@@ -148,45 +276,92 @@ if (!A_Args.Length || (A_Args.Length = 1 && FileExist(A_Args[1]) && A_Args[1] ~=
     Persistent()
     LaunchGui(A_Args.Length ? A_Args[1] : unset, SelectedTab?)
 } else {
-    Command := "", Targets := [], Files := [], LastSwitch := "", Switches := Mapi("main", "", "files", [], "alias", "")
+    Command := "", Targets := [], LastSwitch := "", Switches := Mapi("main", "", "files", [], "alias", "", "help", [])
     for i, Arg in A_Args {
         Arg := Trim(Arg, "`"'")
-        if LastSwitch = "main" {
-            LastSwitch := "", Switches["main"] := StrReplace(Arg, "\", "/")
-            continue
-        } else if LastSwitch = "alias" {
-            LastSwitch := "", Switches["alias"] := Arg
-            continue
+
+        switch LastSwitch, 0 {
+            case "main":
+                LastSwitch := ""
+                Switches["main"] := StrReplace(Arg, "\", "/")
+                continue
+        
+            case "help":
+                LastSwitch := ""
+                Switches["help"] := StrSplit(Arg, ",")
+                continue
+                
+            case "alias":
+                LastSwitch := ""
+                Switches["alias"] := Arg
+                continue
         }
+
         if g_CommandAliases.Has(Arg)
             Command := g_CommandAliases[Arg]
         else if g_SwitchAliases.Has(Arg) {
-            if g_SwitchAliases[Arg] = "main" || g_SwitchAliases[Arg] = "files" || g_SwitchAliases[Arg] = "alias" {
-                LastSwitch := g_SwitchAliases[Arg]
-                continue
+            switch g_SwitchAliases[Arg], 0 {
+                case "main", "files", "alias":
+                    LastSwitch := g_SwitchAliases[Arg]
+                    continue
+                    
+                case "help":
+                    LastSwitch := g_SwitchAliases[Arg]
+                    g_Switches["help"] := true
+                    continue
             }
+
             g_Switches[g_SwitchAliases[Arg]] := true
         } else if !Command && !LastSwitch {
             switch Arg, 0 {
                 case "-v", "--version":
                     Print(LoadPackageJson(A_ScriptDir)["version"])
+                    
                 case "--add-to-path":
-                    g_Config["add_to_path"] := 1, SaveSettings(), AddArisToPATH()
-                    Print(IsArisInPATH() ? "Successfully added Aris to PATH" : "Failed to add Aris to PATH (missing rights to write to registry?)")
+                    g_Config["add_to_path"] := 1 
+                    SaveSettings() 
+                    AddArisToPATH()
+                    
+                    if IsArisInPATH()
+                        Print("Successfully added Aris to PATH")
+                    else
+                        PrintError("Failed to add Aris to PATH (missing rights to write to registry?)")
+                        
                 case "--remove-from-path":
-                    g_Config["add_to_path"] := 0, SaveSettings(), RemoveArisFromPATH()
-                    Print(IsArisInPATH() ? "Failed to remove Aris from PATH (missing rights to write to registry?)" : "Successfully removed Aris from PATH")
+                    g_Config["add_to_path"] := 0
+                    SaveSettings()
+                    RemoveArisFromPATH()  
+                    
+                    if IsArisInPATH()
+                        PrintError("Failed to remove Aris from PATH (missing rights to write to registry?)")
+                    else
+                        Print("Successfully removed Aris from PATH")
+                        
                 case "--add-to-shell":
-                    g_Config["add_to_shell"] := 1, SaveSettings(), AddArisShellMenuItem()
-                    Print(IsArisShellMenuItemPresent() ? "Successfully added Aris shell menu item" : "Failed to add Aris to shell menu item (missing rights to write to registry?)")
+                    g_Config["add_to_shell"] := 1
+                    SaveSettings()
+                    AddArisShellMenuItem()  
+                    
+                    if IsArisShellMenuItemPresent()
+                        Print("Successfully added Aris shell menu item")
+                    else
+                        PrintError("Failed to add Aris to shell menu item (missing rights to write to registry?)")
+                
                 case "--remove-from-shell":
-                    g_Config["add_to_shell"] := 0, SaveSettings(), RemoveArisShellMenuItem()
-                    Print(IsArisShellMenuItemPresent() ? "Failed to remove Aris shell menu item (missing rights to write to registry?)" : "Successfully removed Aris shell menu item")
+                    g_Config["add_to_shell"] := 0
+                    SaveSettings()
+                    RemoveArisShellMenuItem()
+                    
+                    if IsArisShellMenuItemPresent()
+                        PrintError("Failed to remove Aris shell menu item (missing rights to write to registry?)")
+                    else
+                        Print("Successfully removed Aris shell menu item")
+                
                 default:
-                    Print("Unknown command. Use install, remove, update, or list."), ExitApp()
+                    PrintError("Unknown command. See --help for supported commands and switches")
+                    ExitApp()
             }
-        }
-        else {
+        } else {
             if LastSwitch = "files" {
                 Switches["files"].Push(StrReplace(Arg, "\", "/"))
                 continue
@@ -195,6 +370,20 @@ if (!A_Args.Length || (A_Args.Length = 1 && FileExist(A_Args[1]) && A_Args[1] ~=
         }
         LastSwitch := ""
     }
+    
+    if g_Switches["help"] {
+        if (Command && Command != 'help')
+             Switches["help"].Push(Command)
+             
+        for key, val in g_Switches {
+            if (val == true && key != 'help')
+                Switches["help"].Push(key)
+        }
+        
+        PrintHelp(Switches["help"])
+        ExitApp()
+    }
+    
     switch Command, 0 {
         case "install":
             if Targets.Length {
@@ -212,13 +401,14 @@ if (!A_Args.Length || (A_Args.Length = 1 && FileExist(A_Args[1]) && A_Args[1] ~=
             if Targets.Length {
                 for target in Targets
                     RemovePackage(target)
-            } else
-                Print("Specify a package to remove.")
+            } else {
+                PrintWarning("Specify a package to remove.")
+            }
         case "update":
             if !FileExist(A_WorkingDir "\package.json") {
-                Print "Missing package.json, cannot update package!"
-                Print '`tInformation: Use "aris install" if you want to install missing dependecies from the projects scripts.'
-                ExitApp
+                PrintError("Missing package.json, cannot update package!")
+                Print('`tInformation: Use "aris install" if you want to install missing dependecies from the projects scripts.', "cyan")
+                ExitApp()
             }
             if Targets.Length {
                 for target in Targets
@@ -291,12 +481,13 @@ SaveGlobalInstalledPackages() {
 OutputAddedIncludesString(InstallType:=0, PackageType:=0) {
     global g_AddedIncludesString
     if !g_AddedIncludesString {
-        Print "No new packages installed"
+        Print("No new packages installed", "yellow")
         return
     }
     Plural := InStr(g_AddedIncludesString := Trim(g_AddedIncludesString), "`n")
-    Print (InstallType = 0 ? "Installed" : "Updated") " " (PackageType = 0 ? "package" (Plural ? "s" : "") : "dependenc" (Plural ? "ies" : "y")) " include directive" (Plural ? "s" : "") ":"
-    Print g_AddedIncludesString
+    
+    Print((InstallType = 0 ? "Installed" : "Updated") " " (PackageType = 0 ? "package" (Plural ? "s" : "") : "dependenc" (Plural ? "ies" : "y")) " include directive" (Plural ? "s" : "") ":")
+    Print(g_AddedIncludesString)
     g_AddedIncludesString := ""
 }
 
@@ -669,19 +860,19 @@ InstallPackage(Package, Update:=0, Switches?) {
     global g_PackageJson, g_InstalledPackages, g_LocalLibDir, g_AddedIncludesString
     CurrentlyInstalled := Mapi()
     if !(Package is Object) {
-        try PackageInfo := InputToPackageInfo(Package,, Switches?)
-        catch as err {
-            Print err.Message (err.Extra ? ": " err.Extra : "")
-            return
-        }
-    } else
+        try 
+            PackageInfo := InputToPackageInfo(Package,, Switches?)
+        catch as err
+            return PrintError(err.Message (err.Extra ? ": " err.Extra : ""))
+    } else {
         PackageInfo := Package
+    }
     if Update && !g_InstalledPackages.Has(PackageInfo.PackageName) && !PackageInfo.IsMain
         Update := 0
     ReadablePackageName := Trim(RemoveAhkSuffix(Package is Object ? Package.PackageName : PackageInfo.PackageName ? PackageInfo.PackageName : Package), "/")
     if !InStr(ReadablePackageName, "/")
         ReadablePackageName := (Package is Object) ? PackageInfo.RepositoryType ":" PackageInfo.Repository : Package
-    Print 'Starting ' (PackageInfo.Global ? "global " : "") (Update ? "update" : "install") ' of package "' ReadablePackageName '"'
+    Print('Starting ' (PackageInfo.Global ? "global " : "") (Update ? "update" : "install") ' of package "' ReadablePackageName '"')
     Result := 0, DownloadResult := 0
     TempDir := A_ScriptDir "\~temp-" Random(100000000, 1000000000)
     if DirExist(TempDir)
@@ -692,7 +883,7 @@ InstallPackage(Package, Update:=0, Switches?) {
         CurrentlyInstalled[PackageName "@" PackageInfo.InstallVersion] := 1
 
     if (Update = 1) && !g_InstalledPackages.Has(PackageInfo.PackageName) && !PackageInfo.IsMain {
-        Print 'Cannot update package "' PackageInfo.PackageName '" as it is not installed.'
+        Print('Cannot update package "' PackageInfo.PackageName '" as it is not installed.', "yellow")
         goto Cleanup
     }
 
@@ -727,16 +918,18 @@ InstallPackage(Package, Update:=0, Switches?) {
             DownloadResult := true
             A_WorkingDir := PrevWorkingDir
         } catch as err {
-            Print "Failed to download package"
-            Print "`t" err.Message (err.Extra ? ": " err.Extra : "")
+            PrintError("Failed to download package")
+            PrintError("`t" err.Message (err.Extra ? ": " err.Extra : ""))
+            
             A_WorkingDir := PrevWorkingDir
             goto Cleanup
         }
     } else {
-        try DownloadResult := DownloadPackageWithDependencies(PackageInfo, TempDir, g_InstalledPackages, Update)
-        catch as err {
-            Print 'Failed to install package "' ReadablePackageName '"'
-            Print "`t" err.Message (err.Extra ? ": " err.Extra : "")
+        try {
+            DownloadResult := DownloadPackageWithDependencies(PackageInfo, TempDir, g_InstalledPackages, Update)
+        } catch as err {
+            PrintError('Failed to install package "' ReadablePackageName '"')
+            PrintError("`t" err.Message (err.Extra ? ": " err.Extra : ""))
             goto Cleanup
         }
     }
@@ -795,7 +988,7 @@ InstallPackage(Package, Update:=0, Switches?) {
         if (MainFileExt == "*" || MainFileNameNoExt == "*")
             Include.Main := ""
         if !(MainFileExt ~= "ahk?\d?$")
-            Print("Warning: package " Include.Author "\" Include.Name " main file does not have an AHK file extension, please verify that the file contents are valid!")
+            PrintWarning("Warning: package " Include.Author "\" Include.Name " main file does not have an AHK file extension, please verify that the file contents are valid!")
 
         InstallEntry := ConstructInstallCommand(Include, Include.InstallVersion (Include.BuildMetadata ? "+" Include.BuildMetadata : ""))
 
@@ -809,9 +1002,10 @@ InstallPackage(Package, Update:=0, Switches?) {
         FileOpen(g_LocalLibDir "\" Include.Author "\" Include.Name ".ahk", "w").Write(HashtagInclude " " (Include.Global ? "%A_MyDocuments%\AutoHotkey\Lib\Aris\" Include.Author "\" : ".\") StrSplit(Include.InstallName, "/",,2)[-1] "\" StrReplace(Include.Main, "/", "\"))
 
         if Update
-            Print 'Package successfully updated to "' IncludePackageName "@" Include.InstallVersion '".'
+            Print('Package successfully updated to "' IncludePackageName "@" Include.InstallVersion '".', "green")
         else
-            Print 'Package "' IncludePackageName "@" Include.InstallVersion '" successfully installed.'
+            Print('Package "' IncludePackageName "@" Include.InstallVersion '" successfully installed.', "green")
+            
         Print("")
     }
 
@@ -834,10 +1028,9 @@ InstallPackage(Package, Update:=0, Switches?) {
 InstallPackageDependencies(From := "", Update := 2) {
     Result := 1
     Dependencies := QueryPackageDependencies(, From)
-    if !Dependencies.Count {
-        Print "No dependencies found"
-        return
-    }
+    if !Dependencies.Count
+        return Print("No dependencies found")
+    
     for PackageName, PackageInfo in Dependencies
         if Update != 0 || (Update = 0 && !g_InstalledPackages.Has(PackageName)) {
             if !InstallPackage(PackageInfo, Update) ; InStr(PackageInfo.DependencyEntry, ":") ? PackageInfo.DependencyEntry : PackageName "@" PackageInfo.Version)
@@ -856,22 +1049,23 @@ UpdatePackage(PackageName) {
         return Print("No matching installed packages found: `"" PackageName "`"")
 
     if Matches.Length > 1 {
-        Print "Multiple matches found:"
+        Print("Multiple matches found:", "cyan")
         for Match in Matches
-            Print "`t" Match.PackageName "@" Match.InstallVersion
+            Print("`t" Match.PackageName "@" Match.InstallVersion)
     } else {
         try {
             if InstallPackage(Matches[1].PackageName "@" g_PackageJson[Matches[1].PackageName], 1)
-                Print "Package successfully updated!`n"
+                Print("Package successfully updated!`n", "green")
         }
     }
 }
 
 UpdateWorkingDirPackage() {
     if !g_PackageJson.Has("name") || !g_PackageJson["name"] {
-        Print "Missing package name from metadata, cannot update package!"
-        ExitApp
+        PrintError("Missing package name from metadata, cannot update package!")
+        ExitApp()
     }
+    
     ThisPackage := ParsePackageName(g_PackageJson["name"])
     MergeJsonInfoToPackageInfo(g_PackageJson, ThisPackage)
     ThisPackage.IsMain := 1
@@ -882,9 +1076,9 @@ UpdateWorkingDirPackage() {
             MsgBox "Aris successfully updated, press OK to restart"
             Run(A_AhkPath ' "' A_ScriptFullPath '"')
         } else {
-            Print "Aris successfully updated"
+            Print("Aris successfully updated", "green")
         }
-        ExitApp
+        ExitApp()
     }
 }
 
@@ -896,7 +1090,7 @@ RemovePackage(PackageName, RemoveDependencyEntry:=true) {
         return 0
 
     if !Matches.Length {
-        Print "No such package installed"
+        Print("No such package installed")
         return 0
     } else if Matches.Length = 1 {
         Match := Matches[1]
@@ -908,17 +1102,17 @@ RemovePackage(PackageName, RemoveDependencyEntry:=true) {
                 for Dependency in Dependencies
                     DepString .= "`n`t" Dependency.PackageName "@" Dependency.DependencyVersion
 
-                Print DepString
+                Print(DepString)
                 return 0
             }
         }
 
         if !ForceRemovePackage(Match, Match.Global ? g_GlobalLibDir : g_LocalLibDir, RemoveDependencyEntry)
-            Print 'Package "' Match.PackageName "@" Match.InstallVersion '" removed!'
+            Print('Package "' Match.PackageName "@" Match.InstallVersion '" removed!')
     } else {
-        Print "Multiple matches found:"
+        Print("Multiple matches found:", "cyan")
         for Match in Matches
-            Print "`t" Match.PackageName "@" Match.InstallVersion
+            Print("`t" Match.PackageName "@" Match.InstallVersion)
         return 0
     }
     return 1
@@ -930,9 +1124,9 @@ ForceRemovePackage(PackageInfo, LibDir, RemoveDependencyEntry:=true) {
         Exec := ExecScript(PackageInfo.Preremove, '"' LibDir "\" StrReplace(PackageInfo.InstallName, "/", "\") '"')
         if Exec.ExitCode {
             if g_Switches["force"]
-                Print "Package preremove script failed with ExitCode " Exec.ExitCode
+                Print("Package preremove script failed with ExitCode " Exec.ExitCode, "yellow")
             else {
-                Print "Package preremove script failed with ExitCode " Exec.ExitCode ", remove aborted"
+                Print("Package preremove script failed with ExitCode " Exec.ExitCode ", remove aborted", "yellow")
                 return Exec.ExitCode
             }
         }
@@ -969,7 +1163,7 @@ ForceRemovePackage(PackageInfo, LibDir, RemoveDependencyEntry:=true) {
     if PackageInfo.HasProp("Postremove") {
         Exec := ExecScript(PackageInfo.Postremove, '"' LibDir "\" PackageInfo.InstallName '"')
         if Exec.ExitCode {
-            Print "Package postremove script failed with ExitCode " Exec.ExitCode
+            Print("Package postremove script failed with ExitCode " Exec.ExitCode, "yellow")
             return Exec.ExitCode
         }
     }
@@ -1057,7 +1251,7 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
     if PackageInfo.HasProp("Preinstall") {
         Exec := ExecScript(PackageInfo.Preinstall, '"' TempDir '"')
         if Exec.ExitCode {
-            Print "Package preinstall script failed with ExitCode " Exec.ExitCode ", install aborted"
+            Print("Package preinstall script failed with ExitCode " Exec.ExitCode ", install aborted", "yellow")
             return 0
         }
     }
@@ -1077,7 +1271,7 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
     ; First download dependencies listed in index.json, except if we are updating our package
     if !CanUpdate && PackageInfo.Dependencies.Count {
         for DependencyName, DependencyVersion in PackageInfo.Dependencies {
-            Print "Found dependency `"" DependencyName "@" DependencyVersion "`", starting install of dependency"
+            Print("Found dependency `"" DependencyName "@" DependencyVersion "`", starting install of dependency")
             DependencyEntry := DependencyEntryToPackageInfo(DependencyName, DependencyVersion)
             DependencyEntry.DependencyEntry := "" ; Clear it to add a semver version to package.json at the end of InstallPackage
             if !DownloadPackageWithDependencies(DependencyEntry, TempDir, Includes)
@@ -1099,7 +1293,7 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
             }
         }
         if Includes.Has(PackageInfo.PackageName) && (Include := Includes[PackageInfo.PackageName]) && (DirExist(TempDir "\" Include.InstallName) || (!Include.Global && DirExist(g_LocalLibDir "\" Include.InstallName)) || (!g_Switches["local_install"] && DirExist(g_GlobalLibDir "\" Include.InstallName))) {
-            Print 'Package "' Include.InstallName '" already installed, skipping...`n'
+            Print('Package "' Include.InstallName '" already installed, skipping...`n')
             PackageInfo.InstallName := StrReplace(Include.InstallName, "\", "/")
             return Include
         }
@@ -1110,9 +1304,9 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
     VerifyPackageIsDownloadable(PackageInfo)
     if !IsVersioned && IsPackageInstalled(PackageInfo, Includes, [TempDir, g_LocalLibDir, g_GlobalLibDir]) && IsVersionCompatible(PackageInfo.Version, "=" PackageInfo.InstallVersion) {
         if CanUpdate
-            Print 'Package "' PackageInfo.PackageName "@" PackageInfo.Version '" has no matching updates available'
+            Print('Package "' PackageInfo.PackageName "@" PackageInfo.Version '" has no matching updates available')
         else
-            Print 'Package "' PackageInfo.PackageName "@" PackageInfo.Version '" is already installed'
+            Print('Package "' PackageInfo.PackageName "@" PackageInfo.Version '" is already installed')
         return 0
     }
 
@@ -1125,7 +1319,7 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
         A_Clipboard := PackageInfo.Postdownload
         Exec := ExecScript(PackageInfo.Postdownload, '"' TempDir "\" FinalDirName '"')
         if Exec.ExitCode {
-            Print "Package postdownload script failed with ExitCode " Exec.ExitCode ", install aborted"
+            Print("Package postdownload script failed with ExitCode " Exec.ExitCode ", install aborted", "yellow")
             DirDelete('"' TempDir "\" FinalDirName '"')
             return 0
         }
@@ -1240,9 +1434,9 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
 
         PackageJson := LoadJson(TempDir "\" FinalDirName "\package.json")
         if PackageJson.Has("dependencies") {
-            Print "Found dependencies in extracted package manifest"
+            Print("Found dependencies in extracted package manifest")
             for DependencyName, DependencyVersion in PackageJson["dependencies"] {
-                Print "Starting install of dependency " DependencyName "@" DependencyVersion
+                Print("Starting install of dependency " DependencyName "@" DependencyVersion)
                 DependencyEntry := DependencyEntryToPackageInfo(DependencyName, DependencyVersion)
                 DownloadPackageWithDependencies(DependencyEntry, TempDir, Includes)
             }
@@ -1252,7 +1446,7 @@ DownloadPackageWithDependencies(PackageInfo, TempDir, Includes, CanUpdate:=false
     if PackageInfo.HasProp("Postinstall") {
         Exec := ExecScript(PackageInfo.Postinstall, '"' TempDir '"')
         if Exec.ExitCode {
-            Print "Package postinstall script failed with ExitCode " Exec.ExitCode ", install aborted"
+            Print("Package postinstall script failed with ExitCode " Exec.ExitCode ", install aborted", "yellow")
             return 0
         }
     }
@@ -1382,7 +1576,7 @@ DownloadSinglePackage(PackageInfo, TempDir, LibDir) {
             || FileExist(sevenZipPath := A_ScriptDir "\assets\7za.exe")
             || FileExist(sevenZipPath := A_ScriptDir "\assets\7z-x" (A_PtrSize = 4 ? "32" : "64") ".exe") 
             || FileExist(sevenZipPath := A_ScriptDir "\assets\7za-x" (A_PtrSize = 4 ? "32" : "64") ".exe") {
-            Print "The current Windows version doesn't support extracting " ZipExt " files, falling back to 7-zip..."
+            Print("The current Windows version doesn't support extracting " ZipExt " files, falling back to 7-zip...", "yellow")
             RunWait '"' sevenZipPath '" ' sevenZipcmd,, "Hide"
             if !DirExist(TempDir "\" TempDownloadDir)
                 throw Error("Failed to extract package with 7-Zip")
@@ -1541,7 +1735,7 @@ VerifyPackageIsDownloadable(PackageInfo) {
             Print("No GitHub releases found, querying commits instead.")
             if !((commits := ((CommitsPath := GetPathForGitHubCommits(PackageInfo.Files)) != "" ? QueryGitHubRepo(PackageInfo.Repository, "commits?per_page=100&path=" CommitsPath) : QueryGitHubCommits(PackageInfo.Repository))) && commits is Array && commits.Length) {
                 if (commits && commits.Has("status") && commits["status"] == "403")
-                    Print "`nWarning: GitHub query returned error message: `"" commits["message"] "`"`n"
+                    PrintWarning("`nWarning: GitHub query returned error message: `"" commits["message"] "`"`n")
                 throw Error("Unable to find releases or commits for the specified GitHub repository", -1, PackageInfo.PackageName)
             }
             
@@ -1568,7 +1762,7 @@ VerifyPackageIsDownloadable(PackageInfo) {
             TargetAsset := PackageInfo.BuildMetadata && InStr(PackageInfo.BuildMetadata, ".") ? PackageInfo.BuildMetadata : ""
             if TargetAsset && release.Has("assets") && (FoundAssets := FindMatchingAssets(TargetAsset, release["assets"])) && FoundAssets.Length {
                 if !FoundAssets.Length {
-                    Print "`nWarning: detected a potential release file match pattern in build metadata `"" PackageInfo.BuildMetadata "`", but it did not match any release assets. Falling back to the source code zip file..."
+                    PrintWarning("`nWarning: detected a potential release file match pattern in build metadata `"" PackageInfo.BuildMetadata "`", but it did not match any release assets. Falling back to the source code zip file...")
                 } else if FoundAssets.Length == 1 {
                     release["assets"] := FoundAssets
                     PackageInfo.BuildMetadata := FoundAssets[1]["name"]
@@ -1766,7 +1960,7 @@ LoadConfig() {
 }
 
 DownloadPackageIndex() {
-    Print "Checking for index updates..."
+    Print("Checking for index updates...")
     try {
         Download(g_GitHubRawBase "assets/index.json", A_ScriptDir "\assets\~index.json")
         if !g_Config.Has("auto_update_index_daily") || g_Config["auto_update_index_daily"] {
@@ -1777,14 +1971,14 @@ DownloadPackageIndex() {
             DownloadedIndex := JSON.Load(DownloadedIndexContent)
             if Integer(StrSplit(DownloadedIndex['version'], ".")[1]) = Integer(StrSplit(g_Index.Version, ".")[1]) {
                 FileMove(A_ScriptDir "\assets\~index.json", A_ScriptDir "\assets\index.json", 1)
-                Print "Index successfully updated to latest version"
+                Print("Index successfully updated to latest version", "green")
             } else {
-                Print "Incompatible index.json version, ARIS update is recommended"
+                Print("Incompatible index.json version, ARIS update is recommended", "yellow")
             }
         } else
-            Print "Index is already up-to-date"
-    } catch {
-        Print "Failed to download index.json"
+            Print("Index is already up-to-date")
+    } catch as err {
+        PrintError("Failed to download index.json. " err.Message (err.Extra ? ": " err.Extra : ""))
     }
     try FileDelete(A_ScriptDir "\assets\~index.json")
 }
@@ -1798,17 +1992,17 @@ ListInstalledPackages() {
     if g_Switches["global_install"] {
         for PackageName, InstallInfo in g_GlobalInstalledPackages {
             for InstallName, ProjectArray in InstallInfo {
-                Print InstallName "`n`tDependant projects:"
+                Print(InstallName "`n`tDependant projects:", "cyan")
                 for Project in ProjectArray
-                    Print "`t" Project
+                    Print("`t" Project)
             }
         }
     } else {
         Packages := QueryInstalledPackages()
         for _, Package in Packages
-            Print Package.PackageName "@" Package.InstallVersion (Package.Global ? " (global)" : "")
+            Print(Package.PackageName "@" Package.InstallVersion (Package.Global ? " (global)" : ""))
         else
-            Print "No packages installed"
+            Print("No packages installed")
     }
 }
 
@@ -1834,9 +2028,10 @@ QueryInstalledPackages(path := ".\") {
         ExtraInfo := RegExReplace(FileRead(LibDir "\" Path ".ahk"), "i)^[\t; ]*#include (\.|%A_MyDocuments%)[\\\/](([^@]+[\\\/]))*")
         ExtraInfoSplit := StrSplit(ExtraInfo, "\")
 
-        try PackageInfo := InstallInfoToPackageInfo(Path, StrSplit(ExtraInfoSplit[1], "@",, 2)[2], ExtraInfoSplit[-1], IncludeInfo.Count = 2 ? IncludeInfo[2] : "")
+        try 
+            PackageInfo := InstallInfoToPackageInfo(Path, StrSplit(ExtraInfoSplit[1], "@",, 2)[2], ExtraInfoSplit[-1], IncludeInfo.Count = 2 ? IncludeInfo[2] : "")
         catch as err {
-            Print err.Message (err.Extra ? ": " err.Extra : "")
+            PrintError(err.Message (err.Extra ? ": " err.Extra : ""))
             continue
         }
         if !PackageJson["dependencies"].Has(PackageInfo.PackageName)
@@ -1855,9 +2050,10 @@ QueryPackageDependencies(path := ".\", From := "") {
     if !From || From = "package.json" {
         PackageJson := path = ".\" ? g_PackageJson : LoadPackageJson(path)
         for PackageName, VersionRange in PackageJson["dependencies"] {
-            try Packages[PackageName] := DependencyEntryToPackageInfo(PackageName, VersionRange)
+            try 
+                Packages[PackageName] := DependencyEntryToPackageInfo(PackageName, VersionRange)
             catch as err
-                Print "Invalid dependency! " err.Message (err.Extra ? ": " err.Extra : "")
+                PrintError("Invalid dependency! " err.Message (err.Extra ? ": " err.Extra : ""))
         }
     }
     if (!From || From = "packages.ahk") && FileExist(LibDir "\packages.ahk") {
@@ -1888,9 +2084,10 @@ ReadIncludesFromFile(path) {
         if !RegExMatch(A_LoopField, "i)^[\t; ]*#include (?:<Aris|\.)[\\\/]([^>]+?)(?:>|\.ahk)(?: `; )?(.*)?", &IncludeInfo := "")
             continue
 
-        try Packages.Push(InstallInfoToPackageInfo(IncludeInfo[1],,, IncludeInfo.Count = 2 ? IncludeInfo[2] : ""))
+        try
+            Packages.Push(InstallInfoToPackageInfo(IncludeInfo[1],,, IncludeInfo.Count = 2 ? IncludeInfo[2] : ""))
         catch as err {
-            Print err.Message (err.Extra ? ": " err.Extra : "") 
+            PrintError(err.Message (err.Extra ? ": " err.Extra : ""))
         }
     }
     return Packages
@@ -1903,25 +2100,25 @@ CleanPackages() {
         InstalledMap[PackageInfo.PackageName] := PackageInfo
     }
 
-    Print "Removing unused entries from package.json"
+    Print("Removing unused entries from package.json")
     if FileExist("package.json") {
         for Dependency, Version in g_PackageJson["dependencies"] {
             if InstalledMap.Has(Dependency)
                 Dependencies[Dependency] := Version
             else
-                Print "Removing unused dependency " Dependency ": " Version
+                Print("Removing unused dependency " Dependency ": " Version)
         }
         g_PackageJson["dependencies"] := Dependencies
         if (NewContent := JSON.Dump(g_PackageJson, true)) && (NewContent != FileRead("package.json"))
             FileOpen("package.json", "w").Write(NewContent)
     }
 
-    Print "Removing unused global package entries"
+    Print("Removing unused global package entries")
     for PackageName, InstallInfo in g_GlobalInstalledPackages.Clone() {
         for InstallName, ProjectArray in InstallInfo.Clone() {
             Loop ArrLen := ProjectArray.Length {
                 if !DirExist(ProjectArray[ArrLen-A_Index+1]) {
-                    Print "Project folder `"" ProjectArray[ArrLen-A_Index+1] "`" not found, deleting entry for " PackageName
+                    Print("Project folder `"" ProjectArray[ArrLen-A_Index+1] "`" not found, deleting entry for " PackageName)
                     ProjectArray.RemoveAt(ArrLen-A_Index+1)
                 }
             }
@@ -1933,7 +2130,7 @@ CleanPackages() {
     }
 
     for LibDir in [g_LocalLibDir, g_GlobalLibDir] {
-        Print "Cleaning " (LibDir = g_LocalLibDir ? "local" : "global") " library directory"
+        Print("Cleaning " (LibDir = g_LocalLibDir ? "local" : "global") " library directory")
         InstalledPackageMap := LibDir = g_LocalLibDir ? InstalledMap : g_GlobalInstalledPackages
         Loop files LibDir "\*.*", "D" {
             Author := A_LoopFileName
@@ -1943,7 +2140,7 @@ CleanPackages() {
                 else
                     Name := StrSplitLast(A_LoopFileName, ".")[1], DeleteFunc := FileDelete
                 if !InstalledPackageMap.Has(Author "/" Name) {
-                    Print "Deleting unused " (DeleteFunc = FileDelete ? "file" : "directory") " Author\" A_LoopFileName
+                    Print("Deleting unused " (DeleteFunc = FileDelete ? "file" : "directory") " Author\" A_LoopFileName)
                     DeleteFunc(A_LoopFileFullPath)
                 }
             }
@@ -1954,7 +2151,7 @@ CleanPackages() {
     if !FileExist(g_LocalLibDir "\packages.ahk")
         return
 
-    Print "Removing unused entries from packages.ahk"
+    Print("Removing unused entries from packages.ahk")
     OldContent := NewContent := FileRead(g_LocalLibDir "\packages.ahk")
     Loop parse NewContent, "`n", "`r" {
         if !RegExMatch(A_LoopField, "i)^[\t; ]*#include (?:<Aris|\.|%A_MyDocuments%)[\\\/]([^>]+?)(?:>|\.ahk)(?: `; )?(.*)?", &IncludeInfo := "")
@@ -1963,13 +2160,13 @@ CleanPackages() {
         if InstalledMap.Has(IncludeInfo[1])
             continue
 
-        Print "Removing unused include: " A_LoopField
+        Print("Removing unused include: " A_LoopField)
         NewContent := StrReplace(NewContent, A_LoopField "`n")
     }
     if OldContent != NewContent
         FileOpen(g_LocalLibDir "\packages.ahk", "w").Write(NewContent)
 
-    Print "Cleaning packages complete"
+    Print("Cleaning packages complete")
 }
 
 RemovePackageFromGlobalInstallEntries(PackageInfo) {
@@ -2224,9 +2421,3 @@ LoadPackageJson(path:=".\", &RawContent:="") {
     return PackageJson
 }
 LoadJson(fileName, &RawContent:="") => JSON.Load(RawContent := FileRead(fileName))
-
-Print(msg) {
-    try FileAppend(msg "`n", "*")
-    Print.Buffer .= msg != "" && InStr(Print.Buffer, msg) ? "" : msg "`n"
-}
-PrintError(exception, mode) => (Print("Uncaught error on line " exception.Line ": " exception.Message "`n" (exception.Extra ? "`tSpecifically: " exception.Extra "`n" : "")), 1)

--- a/lib/OrderedMap.ahk
+++ b/lib/OrderedMap.ahk
@@ -1,0 +1,91 @@
+class OrderedMap extends Map {
+    __New(keyValuePairs*) {
+        super.CaseSense := "Off"
+        super.__New(keyValuePairs*)
+        
+        keysArray := []
+        keysCount := keyValuePairs.length // 2
+        keysArray.length := keysCount
+
+        loop keysCount
+            keysArray[A_Index] := keyValuePairs[(A_Index << 1) - 1]
+
+        this.keysArray := keysArray
+    }
+
+    __Item[key] {
+        set {
+            if !this.Has(key)
+                this.keysArray.Push(key)
+
+            return super[key] := value
+        }
+    }
+
+    Clear() {
+        super.Clear()
+        this.keysArray := []
+    }
+
+    Clone() {
+        other := super.Clone()
+        other.keysArray := this.keysArray.Clone()
+        return other
+    }
+
+    Delete(key) {
+        try {
+            removedValue := super.Delete(key)
+
+            caseSense := this.caseSense
+            for index, element in this.keysArray {
+                areSame := (element is String)
+                         ? !StrCompare(element, key, caseSense)
+                         : (element = key)
+
+                if areSame {
+                    this.keysArray.RemoveAt(index)
+                    break
+                }
+            }
+
+            return removedValue
+        } catch Error as err {
+            throw Error(err.message, -1, err.extra)
+        }
+    }
+
+    Set(keyValuePairs*) {
+        if (keyValuePairs.length & 1)
+            throw ValueError('Invalid number of parameters.', -1)
+
+        keysArray := this.keysArray
+        keysCount := keyValuePairs.length // 2
+        keysArray.capacity += keysCount
+
+        loop keysCount {
+            key := keyValuePairs[(A_Index << 1) - 1]
+
+            if !this.Has(key)
+                keysArray.Push(key)
+        }
+
+        super.Set(keyValuePairs*)
+        return this
+    }
+
+    __Enum(*) {
+        keyEnum := this.keysArray.__Enum(1)
+
+        keyValEnum(&key := unset, &val := unset) {
+            if keyEnum(&key) {
+                val := this[key]
+                return true
+            } else {
+                return false
+            }
+        }
+
+        return keyValEnum
+    }
+}

--- a/lib/print.ahk
+++ b/lib/print.ahk
@@ -1,0 +1,87 @@
+AttachConsole() {
+    if !DllCall("AttachConsole", "UInt", 0x0ffffffff, "ptr")
+        return false
+        
+    static STD_INPUT_HANDLE   := -10
+    static STD_OUTPUT_HANDLE  := -11
+    static STD_ERROR_HANDLE   := -12
+
+    OnExit((*) => DllCall("FreeConsole"))
+    hConsole := DllCall("GetStdHandle", "int", STD_OUTPUT_HANDLE)  
+    
+    ; Enable ANSI codes processing
+    if DllCall("GetConsoleMode", "Ptr", hConsole, "UIntP", &mode := 0) {
+        mode |= 0x0004  ; ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        DllCall("SetConsoleMode", "Ptr", hConsole, "UInt", mode)
+    }
+    
+    return hConsole
+}
+
+; https://gist.github.com/JBlond/2fea43a3049b38287e5e9cefc87b2124
+Colorize(msg, regex := "", color := "white", bold := false) {
+    static colors := Map(
+        "black",    30,
+        "red",      31,
+        "yellow",   33,
+        "gray",     90,
+        "green",    92,
+        "blue",     94,
+        "purple",   95,
+        "cyan",     96,
+    )
+    
+    if (!color || color = "white")
+        return msg
+    
+    code  := colors.Get(color, 37)  
+    
+    static esc := Chr(27)
+    static end := esc "[0m"
+    begin      := esc "[" bold ";" code "m"
+    
+    if !regex
+        return begin . msg . end
+
+    return RegExReplace(
+        msg, 
+        regex,
+        begin "$1" end
+    )
+}
+
+DeColorize(str) {
+    static esc := Chr(27)
+
+    return RegExReplace(
+        str, 
+        "U)" esc "\[\d+;\d+m(.+)" esc "\[0m", 
+        "$1"
+    )
+}
+
+Print(msg, color := "white", bold := false, icon := '') {
+    static hConsole := AttachConsole()
+    
+    msg .= "`n"
+    
+    try 
+        FileAppend(msg.Color(, color, bold), "*")
+    catch
+        MsgBox(msg.Strip(), "Aris", icon)
+    
+    if !(msg && InStr(Print.Buffer, msg))
+        Print.Buffer .= msg
+
+    return false
+}
+
+PrintError(msg, *)   => (Print(msg, "red", ,    "Iconx"), true)
+PrintWarning(msg, *) => (Print(msg, "yellow", , "Icon!"), true)
+
+PrintException(ex, *) {
+    return PrintError(
+        "Uncaught error on line " ex.Line ": " ex.Message "`n" 
+        . (ex.Extra ? "`tSpecifically: " ex.Extra "`n" : "")
+    )
+}

--- a/lib/ui-main.ahk
+++ b/lib/ui-main.ahk
@@ -136,7 +136,8 @@ LaunchGui(FileOrDir?, SelectedTab := 1) {
     g_MainGui.Show("w" g_MainGui.Width " h" g_MainGui.Height)
     P.Metadata.Opt("+ReadOnly") ; If this isn't done after showing the GUI, the Edit may display black if the cursor was located inside of it
 
-    Print.DefineProp("call", {call:(this, msg) => ((ctrl := ((g_MainGui.Tabs.Value = 1) ? g_MainGui.Tabs.Package.Metadata : g_MainGui.Tabs.Index.Metadata), ctrl.Value .= msg "`n", PostMessage(0x115, 7, 0,, ctrl.hWnd)))})
+    Print.DefineProp("call", {call:(this, msg, *) => ((ctrl := ((g_MainGui.Tabs.Value = 1) ? g_MainGui.Tabs.Package.Metadata : g_MainGui.Tabs.Index.Metadata), ctrl.Value .= msg "`n", PostMessage(0x115, 7, 0,, ctrl.hWnd)))})
+
     if Print.Buffer
         Print(Trim(Print.Buffer)), Print.Buffer := ""
 
@@ -153,10 +154,10 @@ LaunchGui(FileOrDir?, SelectedTab := 1) {
     */
 
     if IsSet(OutFileName) && OutFileName {
-        Print "Installing dependencies from `"" OutFileName "`"`n"
+        Print("Installing dependencies from `"" OutFileName "`"`n")
         PackageAction(P, "install-external", FileOrDir, 0)
         if FileExist("package.json") {
-            Print "`n----------------------------------------------------`nInstalling packages from package.json`n"
+            Print("`n----------------------------------------------------`nInstalling packages from package.json`n")
             PackageAction(P, "install-external", "package.json", 0)
         }
     }
@@ -169,14 +170,14 @@ LaunchGui(FileOrDir?, SelectedTab := 1) {
 }
 
 CheckArisUpdate() {
-    Print "Checking for Aris updates..."
+    Print("Checking for Aris updates...")
     if !(releases := QueryGitHubReleases("Descolada/ARIS/main")) || !(releases is Array) || !releases.Length {
-        Print "Couldn't find any Aris releases"
+        Print("Couldn't find any Aris releases")
         return
     }
     PackageJson := LoadPackageJson(A_ScriptDir)
     if VerCompare(releases[1]["tag_name"], PackageJson["version"]) <= 0 {
-        Print "Aris is already up-to-date"
+        Print("Aris is already up-to-date")
         return
     }
     
@@ -409,7 +410,7 @@ LoadPackageFolder(FullPath) {
         SaveSettings()
     } catch Error as err {
         Print("Failed to load package from " FullPath)
-        PrintError(err, 0)
+        Print(err.Message (err.Extra ? ": " err.Extra : ""))
         FullPath := FullPath == PrevWorkingDir ? A_ScriptDir : PrevWorkingDir
         SetWorkingDir(FullPath)
         RefreshWorkingDirGlobals()


### PR DESCRIPTION
## Colorful output
After messing around with colors for [Launcher project](https://github.com/JoyHak/Launcher) I found a way to make fast color-formatting for console output. `String.Prototype.Color()` in `Aris/Lib/Print.ahk` now applies [ANSI codes](https://gist.github.com/JBlond/2fea43a3049b38287e5e9cefc87b2124) to the target message and `Print()` outputs formatted message to the `CONOUT$` (`*`). I also added wrappers for warnings and errors in `Aris/Lib/Print.ahk`.
<img width="1073" height="968" alt="aris0" src="https://github.com/user-attachments/assets/97fcc19e-8f3c-4e92-b7d9-9b92f71c0130" />

## Help message
For some reason Aris misses very important `--help`, `-h` switch. Now it can display help message:
| example | description |
|--------|--------|
| aris -h | detailed help message |
| aris _install_ -h | specific command help |
|  aris _--force_ -h | specific switch help |
|  aris -h _commands_ | specific help topic |
|  aris -h _commands_,_switches_,... | specific help topics |

<img width="1552" height="1037" alt="help-message" src="https://github.com/user-attachments/assets/1f535fe6-275f-4682-840e-0a44aeee4c75" />

<img width="2058" height="996" alt="help2" src="https://github.com/user-attachments/assets/4de8fa53-7c1e-4ef5-bccd-f6810aa3754f" />

I don't understand how `--alias` works, so it's missing here, please add it. Also I don't understand other switches: `--global`, `--local`, `--main`. Please revise help message.
